### PR TITLE
feat : github Actions를 활용한 CI 스크립트 작성

### DIFF
--- a/.github/.workflows/ci_backend.yml
+++ b/.github/.workflows/ci_backend.yml
@@ -1,0 +1,31 @@
+name: Java CI with Gradle
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  build:
+    runs-on: ubuntu-latest #실행 환경
+
+    #작업의 실행 단계를 정의
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Grant execute permisson for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew clean build


### PR DESCRIPTION
## 개요
- github Actions 에서 자동으로 테스트를 돌리기 위한 ci 스크립트 작성.
    - 트리거 조건: main, develop 브랜치에 PR을 날릴 때 / main, develop 브랜치에 push가 될 때
    - 테스트가 성공하면 녹색 체크표시가, 실패하면 적색 엑스표시가 뜹니다.

## 작업 사항
- github actions 서버를 이용한 CI(Continuous Integration, 지속적 통합) 스크립트를 작성했습니다. CI/CD 학습을 원하신다면 [이 글](https://www.redhat.com/ko/topics/devops/what-is-ci-cd)을 참고해주세요.
- 이제 github actions에서 자동으로 테스트를 수행해줍니다.

## 주의 사항
- 자동 테스트가 잘 되는지 확인

closed : #3 